### PR TITLE
Smooth some linter errors and style issues out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ vendor/
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+*~

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -47,6 +47,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e648767d2cf13030fe492dcbabd1ae1575f9d28bfaea2aa3e5702b3f0d6540a8"
+  inputs-digest = "64f5db620c147fa5bb394223e4833aa4d4dce1c1867bb82c86b6d4c299699ea7"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/artesia/app/config.go
+++ b/cmd/artesia/app/config.go
@@ -1,9 +1,11 @@
 package app
 
+// Config contains config data for the server
 type Config struct {
-	ListenAddress string `toml:"listen_address`
+	ListenAddress string
 }
 
+// NewDefaultConfig returns a default config
 func NewDefaultConfig() *Config {
 	return &Config{
 		ListenAddress: "127.0.0.1:8080",

--- a/cmd/artesia/app/server.go
+++ b/cmd/artesia/app/server.go
@@ -9,11 +9,13 @@ import (
 	"go.uber.org/zap"
 )
 
+// Server contains information needed to start the HTTP Server
 type Server struct {
 	Log        *zap.SugaredLogger
 	httpServer *http.Server
 }
 
+// NewServer creates an instance of Server
 func NewServer() (*Server, error) {
 	bindAddress := "0.0.0.0:8080"
 
@@ -41,6 +43,7 @@ func NewServer() (*Server, error) {
 	return server, nil
 }
 
+// Run runs the HTTP Server
 func (s *Server) Run() error {
 	s.Log.Infof("Server listening on: %s", s.httpServer.Addr)
 	return s.httpServer.ListenAndServe()

--- a/cmd/artesia/main.go
+++ b/cmd/artesia/main.go
@@ -8,8 +8,9 @@ import (
 	"github.com/kennydo/artesia/cmd/artesia/app"
 )
 
+var configFilePath = flag.String("config", "configs/config.toml", "Path to the config file")
+
 func main() {
-	configFilePath := flag.String("config", "configs/config.toml", "Path to the config file")
 	flag.Parse()
 
 	config := app.NewDefaultConfig()


### PR DESCRIPTION
Fixed some linter warnings that `gometalinter` was warning me about, and pushed the flag definition outside of `main` as per the docs.