### PR TITLE
Return dummy data for `/api/v1/instance` and `/api/v1/apps` endpoints

### DIFF
--- a/cmd/artesia/app/controllers/apps.go
+++ b/cmd/artesia/app/controllers/apps.go
@@ -1,0 +1,23 @@
+package controllers
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// OAuthCredentials holds the data required for OAuth apps to authenticate to us
+type OAuthCredentials struct {
+	ID           string `json:"id"`
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+}
+
+// RegisterOAuthApplication creates new OAuth credentials for users
+func RegisterOAuthApplication(w http.ResponseWriter, r *http.Request) {
+	credentials := OAuthCredentials{
+		ID:           "imouto",
+		ClientID:     "imoutoID",
+		ClientSecret: "imoutoHimitsu",
+	}
+	json.NewEncoder(w).Encode(credentials)
+}

--- a/cmd/artesia/app/controllers/apps.go
+++ b/cmd/artesia/app/controllers/apps.go
@@ -3,6 +3,8 @@ package controllers
 import (
 	"encoding/json"
 	"net/http"
+
+	"go.uber.org/zap"
 )
 
 // OAuthCredentials holds the data required for OAuth apps to authenticate to us
@@ -13,7 +15,7 @@ type OAuthCredentials struct {
 }
 
 // RegisterOAuthApplication creates new OAuth credentials for users
-func RegisterOAuthApplication(w http.ResponseWriter, r *http.Request) {
+func RegisterOAuthApplication(log *zap.SugaredLogger, w http.ResponseWriter, r *http.Request) {
 	credentials := OAuthCredentials{
 		ID:           "imouto",
 		ClientID:     "imoutoID",

--- a/cmd/artesia/app/controllers/instances.go
+++ b/cmd/artesia/app/controllers/instances.go
@@ -3,6 +3,8 @@ package controllers
 import (
 	"encoding/json"
 	"net/http"
+
+	"go.uber.org/zap"
 )
 
 // URLs has data about related URLs for this instance
@@ -22,7 +24,7 @@ type Instance struct {
 }
 
 // GetCurrentInstance returns information about this instance
-func GetCurrentInstance(w http.ResponseWriter, r *http.Request) {
+func GetCurrentInstance(log *zap.SugaredLogger, w http.ResponseWriter, r *http.Request) {
 	currentInstance := Instance{
 		URI:         r.Host,
 		Title:       "artesia",

--- a/cmd/artesia/app/controllers/instances.go
+++ b/cmd/artesia/app/controllers/instances.go
@@ -1,0 +1,38 @@
+package controllers
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// URLs has data about related URLs for this instance
+type URLs struct {
+	StreamingAPI string `json:"streaming_api"`
+}
+
+// Instance holds data about this current instance
+type Instance struct {
+	URI         string   `json:"uri"`
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
+	Email       string   `json:"email"`
+	Version     string   `json:"version"`
+	URLs        URLs     `json:"urls"`
+	Languages   []string `json:"languages"`
+}
+
+// GetCurrentInstance returns information about this instance
+func GetCurrentInstance(w http.ResponseWriter, r *http.Request) {
+	currentInstance := Instance{
+		URI:         r.Host,
+		Title:       "artesia",
+		Description: "Lorem ipsum imouto",
+		Email:       "artesia@example.com",
+		Version:     "2.4.0 (compatible; Artesia dev)",
+		URLs: URLs{
+			StreamingAPI: "",
+		},
+		Languages: []string{"en", "jp"},
+	}
+	json.NewEncoder(w).Encode(currentInstance)
+}

--- a/cmd/artesia/app/controllers/method_not_allowed.go
+++ b/cmd/artesia/app/controllers/method_not_allowed.go
@@ -1,0 +1,17 @@
+package controllers
+
+import (
+	"net/http"
+
+	"go.uber.org/zap"
+)
+
+// MethodNotAllowed handles requests to paths that don't support a certain method
+func MethodNotAllowed(log *zap.SugaredLogger, w http.ResponseWriter, r *http.Request) {
+	log.Infow(
+		"HTTP method not allowed handler",
+		zap.String("url", r.URL.String()),
+		zap.String("method", r.Method),
+	)
+	w.WriteHeader(http.StatusMethodNotAllowed)
+}

--- a/cmd/artesia/app/controllers/not_found.go
+++ b/cmd/artesia/app/controllers/not_found.go
@@ -1,0 +1,17 @@
+package controllers
+
+import (
+	"net/http"
+
+	"go.uber.org/zap"
+)
+
+// NotFound handles requests to paths that don't have a handle registered
+func NotFound(log *zap.SugaredLogger, w http.ResponseWriter, r *http.Request) {
+	log.Infow(
+		"No HTTP handler found",
+		zap.String("url", r.URL.String()),
+		zap.String("method", r.Method),
+	)
+	w.WriteHeader(http.StatusNotFound)
+}

--- a/cmd/artesia/app/server.go
+++ b/cmd/artesia/app/server.go
@@ -65,6 +65,6 @@ func (s *Server) addMiddleware(h artesiaHandlerFunc) http.HandlerFunc {
 
 // Run runs the HTTP Server
 func (s *Server) Run() error {
-	s.log.Infof("Server listening on: https://%s", s.httpServer.Addr)
+	s.log.Infof("Server listening on: http://%s", s.httpServer.Addr)
 	return s.httpServer.ListenAndServe()
 }

--- a/cmd/artesia/app/server.go
+++ b/cmd/artesia/app/server.go
@@ -35,7 +35,7 @@ func NewServer(config *Config) (*Server, error) {
 
 	// Register error handlers
 	mux.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		sugarLogger.Info(
+		sugarLogger.Infow(
 			"No HTTP handler found",
 			zap.String("url", r.URL.String()),
 			zap.String("method", r.Method),
@@ -44,7 +44,7 @@ func NewServer(config *Config) (*Server, error) {
 	})
 
 	mux.MethodNotAllowedHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		sugarLogger.Info(
+		sugarLogger.Infow(
 			"HTTP method not allowed handler",
 			zap.String("url", r.URL.String()),
 			zap.String("method", r.Method),

--- a/cmd/artesia/app/server.go
+++ b/cmd/artesia/app/server.go
@@ -12,10 +12,12 @@ import (
 
 // Server contains information needed to start the HTTP Server
 type Server struct {
-	Log        *zap.SugaredLogger
+	log        *zap.SugaredLogger
 	httpServer *http.Server
 	config     *Config
 }
+
+type artesiaHandlerFunc func(*zap.SugaredLogger, http.ResponseWriter, *http.Request)
 
 // NewServer creates an instance of Server
 func NewServer(config *Config) (*Server, error) {
@@ -26,31 +28,6 @@ func NewServer(config *Config) (*Server, error) {
 	sugarLogger := logger.Sugar()
 
 	mux := mux.NewRouter()
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode([]string{"Hello", "World"})
-	}).Methods("GET")
-	// Register routes for our app
-	mux.HandleFunc("/api/v1/instance", controllers.GetCurrentInstance).Methods("GET")
-	mux.HandleFunc("/api/v1/apps", controllers.RegisterOAuthApplication).Methods("POST")
-
-	// Register error handlers
-	mux.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		sugarLogger.Infow(
-			"No HTTP handler found",
-			zap.String("url", r.URL.String()),
-			zap.String("method", r.Method),
-		)
-		w.WriteHeader(http.StatusNotFound)
-	})
-
-	mux.MethodNotAllowedHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		sugarLogger.Infow(
-			"HTTP method not allowed handler",
-			zap.String("url", r.URL.String()),
-			zap.String("method", r.Method),
-		)
-		w.WriteHeader(http.StatusMethodNotAllowed)
-	})
 
 	httpServer := &http.Server{
 		Handler:      mux,
@@ -60,16 +37,34 @@ func NewServer(config *Config) (*Server, error) {
 	}
 
 	server := &Server{
-		Log:        sugarLogger,
+		log:        sugarLogger,
 		httpServer: httpServer,
 		config:     config,
 	}
 
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]string{"Hello", "World"})
+	}).Methods("GET")
+
+	// Register routes for our app
+	mux.HandleFunc("/api/v1/instance", server.addMiddleware(controllers.GetCurrentInstance)).Methods("GET")
+	mux.HandleFunc("/api/v1/apps", server.addMiddleware(controllers.RegisterOAuthApplication)).Methods("POST")
+
+	// Register error handlers
+	mux.NotFoundHandler = server.addMiddleware(controllers.NotFound)
+	mux.MethodNotAllowedHandler = server.addMiddleware(controllers.MethodNotAllowed)
+
 	return server, nil
+}
+
+func (s *Server) addMiddleware(h artesiaHandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		h(s.log, w, r)
+	}
 }
 
 // Run runs the HTTP Server
 func (s *Server) Run() error {
-	s.Log.Infof("Server listening on: http://%s", s.httpServer.Addr)
+	s.log.Infof("Server listening on: https://%s", s.httpServer.Addr)
 	return s.httpServer.ListenAndServe()
 }

--- a/lib/services/user/service.go
+++ b/lib/services/user/service.go
@@ -50,7 +50,7 @@ func (s *DBService) CreateUser(email string, plaintextPassword string) (*service
 
 	passwordHashBytes, err := bcrypt.GenerateFromPassword([]byte(plaintextPassword), bcrypt.DefaultCost)
 	if err != nil {
-		s.log.Info("Unable to hash password", zap.Error(err), zap.String("email", email))
+		s.log.Infow("Unable to hash password", zap.Error(err), zap.String("email", email))
 		return nil, fmt.Errorf("Invalid password")
 	}
 
@@ -67,7 +67,7 @@ func (s *DBService) CreateUser(email string, plaintextPassword string) (*service
 		RETURNING id
 		`)
 	if err != nil {
-		s.log.Info("Unable to prepare insert statement", zap.Error(err))
+		s.log.Infow("Unable to prepare insert statement", zap.Error(err))
 		return nil, fmt.Errorf("Unable to prepare user for insert")
 	}
 
@@ -78,11 +78,11 @@ func (s *DBService) CreateUser(email string, plaintextPassword string) (*service
 		CreatedAt:    time.Now().In(time.UTC),
 	})
 	if err != nil {
-		s.log.Info("Unable to insert user into DB", zap.Error(err), zap.String("email", email))
+		s.log.Infow("Unable to insert user into DB", zap.Error(err), zap.String("email", email))
 		return nil, fmt.Errorf("Unable to insert user into DB")
 	}
 
-	s.log.Info("Created new user", zap.Int("id", insertedID), zap.String("email", email))
+	s.log.Infow("Created new user", zap.Int("id", insertedID), zap.String("email", email))
 	user, err := s.GetByID(insertedID)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to get user by ID")


### PR DESCRIPTION
It looks like `toot` calls `/api/v1/apps` first, so I made an endpoint just to return dummy data.

In order to get toot even be able to call my local dev instance, I had to:
1. Install https://github.com/square/ghostunnel
2. `cd test-keys`
3. Run `ghostunnel server --listen 0.0.0.0:8081 --target 127.0.0.1:8080 --keystore server-keystore.p12 --cacert cacert.pem --disable-authentication`
4. Edit `toot/http.py` in my venv to add `verify=False` to the session call