### PR TITLE
Pass in context and sqlx.Tx to user service, switch to using UUIDs for ID

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -85,6 +85,12 @@
   version = "v1.0.0"
 
 [[projects]]
+  name = "github.com/satori/go.uuid"
+  packages = ["."]
+  revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
+  version = "v1.2.0"
+
+[[projects]]
   name = "github.com/spf13/afero"
   packages = [
     ".",
@@ -189,6 +195,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "af3e05a17e9a90404261aa09301efd1250fe3ed53bbdbb24ca13e4f04c85eb16"
+  inputs-digest = "60361a8e3eef5ac650077b847ea97a75db6bade1a543edb200a27a7c225bfc5f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -29,3 +29,7 @@
 [[constraint]]
   name = "github.com/spf13/viper"
   version = "1.0.2"
+
+[[constraint]]
+  name = "github.com/satori/go.uuid"
+  version = "1.2.0"

--- a/db/initdb/schema.sql
+++ b/db/initdb/schema.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 10.4 (Debian 10.4-1.pgdg90+1)
--- Dumped by pg_dump version 10.3 (Ubuntu 10.3-1)
+-- Dumped from database version 10.4 (Debian 10.4-2.pgdg90+1)
+-- Dumped by pg_dump version 10.4 (Debian 10.4-2.pgdg90+1)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -38,7 +38,7 @@ SET default_with_oids = false;
 --
 
 CREATE TABLE public.users (
-    id bigint NOT NULL,
+    id uuid NOT NULL,
     email character varying(256) NOT NULL,
     password_hash character varying(128) NOT NULL,
     created_at timestamp with time zone NOT NULL
@@ -48,46 +48,11 @@ CREATE TABLE public.users (
 ALTER TABLE public.users OWNER TO artesia;
 
 --
--- Name: users_id_seq; Type: SEQUENCE; Schema: public; Owner: artesia
+-- Data for Name: users; Type: TABLE DATA; Schema: public; Owner: artesia
 --
 
-CREATE SEQUENCE public.users_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
-ALTER TABLE public.users_id_seq OWNER TO artesia;
-
---
--- Name: users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: artesia
---
-
-ALTER SEQUENCE public.users_id_seq OWNED BY public.users.id;
-
-
---
--- Name: users id; Type: DEFAULT; Schema: public; Owner: artesia
---
-
-ALTER TABLE ONLY public.users ALTER COLUMN id SET DEFAULT nextval('public.users_id_seq'::regclass);
-
-
---
--- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: artesia
---
-
-ALTER TABLE ONLY public.users
-    ADD CONSTRAINT users_pkey PRIMARY KEY (id);
-
-
---
--- Name: uq_email; Type: INDEX; Schema: public; Owner: artesia
---
-
-CREATE UNIQUE INDEX uq_email ON public.users USING btree (lower((email)::text));
+COPY public.users (id, email, password_hash, created_at) FROM stdin;
+\.
 
 
 --

--- a/lib/services/user.go
+++ b/lib/services/user.go
@@ -13,7 +13,7 @@ var ErrUserEmailTaken = errors.New("User email is taken")
 
 // User represents a local user that can login and do things
 type User struct {
-	ID           int
+	ID           string
 	Email        string
 	PasswordHash string
 	CreatedAt    time.Time
@@ -21,7 +21,7 @@ type User struct {
 
 // UserService exposes CRUD operations on Users
 type UserService interface {
-	GetByID(id int) (*User, error)
+	GetByID(id string) (*User, error)
 	GetByEmail(email string) (*User, error)
 	CreateUser(email string, plaintextPassword string) (*User, error)
 }

--- a/lib/services/user.go
+++ b/lib/services/user.go
@@ -11,6 +11,9 @@ var ErrUserNotFound = errors.New("User not found")
 // ErrUserEmailTaken is returned when a user's email is already taken
 var ErrUserEmailTaken = errors.New("User email is taken")
 
+// ErrUnableToCreateUser is returned when we're unable to create a user
+var ErrUnableToCreateUser = errors.New("Unable to create user")
+
 // User represents a local user that can login and do things
 type User struct {
 	ID           string

--- a/lib/services/user/model.go
+++ b/lib/services/user/model.go
@@ -4,7 +4,7 @@ import "time"
 
 // DBUser represents how a user is stored in the DB
 type DBUser struct {
-	ID           int       `db:"id"`
+	ID           string    `db:"id"`
 	Email        string    `db:"email"`
 	PasswordHash string    `db:"password_hash"`
 	CreatedAt    time.Time `db:"created_at"`

--- a/lib/services/user/service.go
+++ b/lib/services/user/service.go
@@ -58,12 +58,12 @@ func (s *DBService) CreateUser(ctx context.Context, tx *sqlx.Tx, email string, p
 	stmt, err := tx.PrepareNamedContext(
 		ctx,
 		`INSERT INTO users (
-      id,
+			id,
 			email,
 			password_hash,
 			created_at
 		) VALUES (
-      :id,
+			:id,
 			:email,
 			:password_hash,
 			:created_at

--- a/lib/services/user/service_test.go
+++ b/lib/services/user/service_test.go
@@ -50,11 +50,12 @@ func (suite *DBServiceTestSuite) SetupTest() {
 	suite.service = &DBService{
 		log: sugarLogger,
 	}
-	suite.ctx = context.TODO()
+	suite.ctx = context.Background()
 	suite.tx = db.MustBegin()
 }
 
 func (suite *DBServiceTestSuite) TearDownTest() {
+	suite.tx.Rollback()
 }
 
 func (suite *DBServiceTestSuite) TestCreatingUser() {


### PR DESCRIPTION
Web routes should operate inside a DB transaction, so we should pass those in instead of using a global DB connection pool directly.

Web routes will also be using a context, so let's pass those into things too.

Because we won't know what the auto-incrementing user PK ID would be, I also switched to using UUIDs.